### PR TITLE
Fix parallel execution bug (issue #38)

### DIFF
--- a/src/Hyperopt.jl
+++ b/src/Hyperopt.jl
@@ -48,7 +48,7 @@ Lazy.@forward Hyperoptimizer.history Base.length, Base.getindex
 
 function Base.iterate(ho::Hyperoptimizer, state=1)
     state > ho.iterations && return nothing
-    samples = ho.sampler(ho)
+    samples = ho.sampler(ho, state)
     push!(ho.history, samples)
     [state;samples], state+1
 end
@@ -103,6 +103,7 @@ function pmacrobody(ex, params, candidates, sampler_)
         function workaround_function()
             ho = Hyperoptimizer(iterations = $(esc(candidates[1])), params = $(esc(params[2:end])), candidates = $(Expr(:tuple, esc.(candidates[2:end])...)), sampler=$(esc(sampler_)))
             ho.sampler isa GPSampler && error("We currently do not support running the GPSampler in parallel. If this is an issue, open an issue ;)")
+            init!(ho.sampler, ho)
             res = pmap(1:ho.iterations) do i
                 $(Expr(:tuple, esc.(params)...)),_ = iterate(ho,i)
                 res = $(esc(ex.args[2])) # ex.args[2] = Body of the For loop

--- a/src/samplers.jl
+++ b/src/samplers.jl
@@ -2,7 +2,10 @@
 Sample a value For each parameter uniformly at random from the candidate vectors. Log-uniform sampling available by providing a log-spaced candidate vector.
 """
 struct RandomSampler <: Sampler end
-function (s::RandomSampler)(ho)
+
+function init!(::RandomSampler, ho) end
+
+function (s::RandomSampler)(ho, iter)
     [list[rand(1:length(list))] for list in ho.candidates]
 end
 
@@ -26,9 +29,8 @@ function init!(s::LHSampler, ho)
     s.samples = copy(X')
 end
 
-function (s::LHSampler)(ho)
+function (s::LHSampler)(ho, iter)
     init!(s, ho)
-    iter = length(ho.history)+1
     [list[s.samples[dim,iter]] for (dim,list) in enumerate(ho.candidates)]
 end
 
@@ -51,9 +53,8 @@ function init!(s::CLHSampler, ho)
     s.samples = copy(X')
 end
 
-function (s::CLHSampler)(ho)
+function (s::CLHSampler)(ho, iter)
     init!(s, ho)
-    iter = length(ho.history)+1
     [list[s.samples[dim,iter]] for (dim,list) in enumerate(ho.candidates)]
 end
 
@@ -120,7 +121,7 @@ function init!(s::GPSampler, ho)
 end
 
 
-function (s::GPSampler)(ho)
+function (s::GPSampler)(ho, iter)
     init!(s, ho)
     iter = length(ho.history)+1
     if iter <= 3
@@ -226,7 +227,7 @@ end
 function successive_halving(hb, ho, costfun, n, r=1, s=round(Int, log(hb.η, n)))
     η = hb.η
     minimum = Inf
-    T = [ hb.inner(ho) for i=1:n ]
+    T = [ hb.inner(ho, i) for i=1:n ]
     # append!(ho.history, T)
     Juno.progress() do id
         for i in 0:s


### PR DESCRIPTION
This PR attempts to fix the parallel execution bug in #38. That issue was caused because the samplers would tend to infer the iteration number as `iter = length(ho.history)+1`, but the workers would not update `ho.history`, and so the iteration number would always be 1 on the workers. This would cause the sampler to re-initialize at every iteration.

The work-around in this PR is to pass the iteration number to the samplers. I haven't done extensive testing, but this appears to work. There is one test case (GP sampler) that fails, but it fails for me on master too.