### PR TITLE
`RandomSampler`s each carry their own RNG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Hyperopt"
 uuid = "93e5fe13-2215-51db-baaf-2e9a34fb2712"
 author = ["Fredrik Bagge Carlson <baggepinnen@gmail.com>"]
-version = "0.4.4"
+version = "0.4.5"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/src/Hyperopt.jl
+++ b/src/Hyperopt.jl
@@ -13,8 +13,6 @@ using Distributed
 using LatinHypercubeSampling
 using ThreadPools
 
-const HO_RNG = [MersenneTwister(rand(1:1000)) for _ in 1:nthreads()]
-
 abstract type Sampler end
 Base.@kwdef mutable struct Hyperoptimizer{S<:Sampler, F}
     iterations::Int

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -255,6 +255,7 @@ f(a,b=true;c=10) = sum(@. 100 + (a-3)^2 + (b ? 10 : 20) + (c-100)^2) # This func
             # println(i, "\t", a, "\t", b, "\t", c)
             f(a,b,c=c)
         end
+        @test horp.history[1] != horp.history[2]
         @test minimum(horp) < 300
         @test length(horp.history) == 300
         @test length(horp.results) == 300


### PR DESCRIPTION
Currently, we `iterate` the Hyperoptimizer inside the `pmap`, which means each worker is responsible for iterating. Since each worker gets its own copy of the module and the module-level global `HO_RNG`, each worker ends up with the same iterates, as seen in https://github.com/baggepinnen/Hyperopt.jl/issues/32#issuecomment-755799622.

Instead, here we have each `RandomSampler` carry its own RNG, and we ensure it is shared between workers by means of a RemoteChannel. We also use a lock to avoid thread-safety issues with `RemoteChannel`s (https://github.com/JuliaLang/julia/issues/37706). I think these concurency restrictions should not be a performance problem in this context since generating the random numbers should be much faster than training the model (or whatever function evaluation is used), and competing workers/threads won't have to wait long to get access to the RNG.

This should ensure that either in the threaded case or multiprocess case there is only 1 RNG used to avoid issues like https://github.com/baggepinnen/Hyperopt.jl/issues/32#issuecomment-755799622 (which I am experiencing too).

This also allows one to easily pass e.g. a `StableRNG` for reproducibility, e.g. `RandomSampler(StableRNG(123))`.

Note that the test I added fails on master:
```julia
  Expression: horp.history[1] != horp.history[2]
   Evaluated: (1.4081632653061225, true, 0.1456348477501244) != (1.4081632653061225, true, 0.1456348477501244)
```