### PR TITLE
allow passing a custom `pmap`

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,5 @@ end
 
 # Parallel execution
 - The macro `@phyperopt` works in the same way as `@hyperopt` but distributes all computation on available workers. The usual caveats apply, code must be loaded on all workers etc.
-  - `@phyperopt` currently does not update its history while iterating. Therefore samplers which rely on the history won't work correctly.
   - `@phyperopt` accepts an optional second argument which is a `pmap`-like function. E.g. `(args...,) -> pmap(args...; on_error=...)`.
 - The macro `@thyperopt` uses `ThreadPools.tmap` to evaluate the objective on all available threads. Beware of high memory consumption if your objective allocates a lot of memory.

--- a/README.md
+++ b/README.md
@@ -252,4 +252,6 @@ end
 
 # Parallel execution
 - The macro `@phyperopt` works in the same way as `@hyperopt` but distributes all computation on available workers. The usual caveats apply, code must be loaded on all workers etc.
+  - `@phyperopt` currently does not update its history while iterating. Therefore samplers which rely on the history won't work correctly.
+  - `@phyperopt` accepts an optional second argument which is a `pmap`-like function. E.g. `(args...,) -> pmap(args...; on_error=...)`.
 - The macro `@thyperopt` uses `ThreadPools.tmap` to evaluate the objective on all available threads. Beware of high memory consumption if your objective allocates a lot of memory.

--- a/src/Hyperopt.jl
+++ b/src/Hyperopt.jl
@@ -206,6 +206,12 @@ function pmacrobody(ex, params, ho_, pmap=pmap)
                 $(Expr(:tuple, esc.(params)...)), _ = iterate(ho, i)
                 res = $(esc(ex.args[2])) # ex.args[2] = Body of the For loop
 
+                # Here, we update `new_history` (which lives on the manager node thanks to the `RemoteChannel`)
+                # from the worker nodes, so that we don't need to care about the result of pmap.
+                # Why? Because the previous design of returning both the loss and the parameters to collect
+                # and update the history with later would mean that if we pass a custom `on_error`, for example,
+                # it would need to return both a loss and the parameters to be added to the history later,
+                # and the user probably doesn't know they can't just pass a loss.
                 put!(new_history, (i, res, $(Expr(:tuple, esc.(params[2:end])...))))
                 res
             end

--- a/src/Hyperopt.jl
+++ b/src/Hyperopt.jl
@@ -233,8 +233,14 @@ function pmacrobody(ex, params, ho_, pmap=pmap)
             # the original hyperoptimizer.
             updated_ho = take!(ho_channel)
             close(ho_channel)
-            ho.history = updated_ho.history
-            ho.results = updated_ho.results
+
+            # Getting the history right is tricky. For some reason, we can't do `ho.history = updated_ho.history`.
+            # Instead, we must mutate the existing `ho.history` vector. (Similarly for results).
+            empty!(ho.history)
+            append!(ho.history, updated_ho.history)
+
+            empty!(ho.results)
+            append!(ho.results, updated_ho.results)
 
             ho
         end

--- a/src/Hyperopt.jl
+++ b/src/Hyperopt.jl
@@ -199,7 +199,11 @@ function pmacrobody(ex, params, ho_, pmap=pmap)
             # We use a `RemoteChannel` to coordinate access to a single Hyperoptimizer object
             # that lives on the manager process.
             ho_channel = RemoteChannel(() -> Channel{Hyperoptimizer}(1), 1)
-            put!(ho_channel, ho)
+
+            # We use a `deepcopy` to ensure we get the same semantics whether or not the code
+            # ends up executing on a remote process or not (i.e. always a copy). See
+            # <https://docs.julialang.org/en/v1/manual/distributed-computing/#Local-invocations>
+            put!(ho_channel, deepcopy(ho))
 
             # We don't care about the results of the `pmap` since we update the hyperoptimizer
             # inside the loop.


### PR DESCRIPTION
closes #59 

with thanks to @omus who helped me figure out a path here.

I think `@phyperopt` needs more correctness work to go beyond simple samplers like the RandomSampler, but this at least lets us use the RandomSampler robustly by passing e.g. a `Parallelism.robust_pmap` or such.