### PR TITLE
Fix print for non-numeric items in minimization

### DIFF
--- a/src/Hyperopt.jl
+++ b/src/Hyperopt.jl
@@ -65,7 +65,11 @@ function Base.show(io::IO, ho::Hyperoptimizer)
     end
     println(io)
     for (i, v) in enumerate(ho.minimizer)
-        @printf(io, "%9.4g ", v)
+        if v isa Number
+            @printf(io, "%9.4g ", v)
+        else
+            @printf(io, "%9s ", v)
+        end
     end
     println()
 end


### PR DESCRIPTION
Had some errors when testing out something like the categorical example, it didn't like printing the functions.