### PR TITLE
fix symbol plotting

### DIFF
--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -7,18 +7,35 @@ logscale(params) = false
     layout --> N
     for i = 1:N
         params = getindex.(ho.history, i)
-        perm = sortperm(params)
-        yguide --> "Function value"
-        seriestype --> :scatter
-        @series begin
-            xguide --> ho.params[i]
-            subplot --> i
-            label --> "Sampled points"
-            legend --> false
-            xscale --> (logscale(params) ? :log10 : :identity)
-            yscale --> (logscale(ho.results) ? :log10 : :identity)
-            params[perm], ho.results[perm]
+        if eltype(params) <: Real 
+            perm = sortperm(params) 
+            yguide --> "Function value"
+            seriestype --> :scatter
+            @series begin
+                xguide --> ho.params[i]
+                subplot --> i
+                label --> "Sampled points"
+                legend --> false
+                xscale --> (logscale(params) ? :log10 : :identity)
+                yscale --> (logscale(ho.results) ? :log10 : :identity)
+                params[perm], ho.results[perm]
+            end
+        else
+            params = Symbol.(params)
+            uniqueparams = sort(unique(params))
+            paramidxs = map(x -> findfirst(==(x), uniqueparams), params)
+            yguide --> "Function value"
+            seriestype --> :scatter
+            @series begin
+                xguide --> ho.params[i]
+                subplot --> i
+                label --> "Sampled points"
+                legend --> false
+                xticks --> (1:length(uniqueparams), uniqueparams)
+                xscale --> :identity
+                yscale --> (logscale(ho.results) ? :log10 : :identity)
+                paramidxs, ho.results
+            end
         end
-
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -146,6 +146,7 @@ end
     end
 
     @testset "Hyperband" begin
+        @info "Testing Hyperband"
         using Optim
         f(a;c=10) = sum(@. 100 + (a-3)^2 + (c-100)^2)
         # res = map(1:30) do i
@@ -315,5 +316,22 @@ end
     @testset "BOHB" begin
         @info "Testing BOHB"
         include("test_BOHB.jl")
+    end
+
+    @testset "Non-numerics" begin
+        @info "Testing optimizing over non-numeric elements"
+        hor = @hyperopt for i=100, g=[sin, exp, identity], x=LinRange(0,1,100)
+            g(x)
+        end
+        show(hor)
+        @test minimum(hor) < ℯ
+        @test maximum(hor) > 0
+        @test length(hor.history) == 100
+        @test length(hor.results) == 100
+        @test all(hor.history) do h
+            all(hi in hor.candidates[i] for (i,hi) in enumerate(h))
+        end
+
+        plot(hor)
     end
 end


### PR DESCRIPTION
As mentioned in #65 there was also a problem with plotting if the optimization had some parameter that was a list of functions. 

I  set all things that are not real numbers to be handled by this instead and then group all values by their parameter value.

Not very experienced with the `@recipes` but I think I got something that works for a few test cases I threw at it at least.

Didn't really see the reason for the `perm` so removed it for the second case, though left it for the original.