### PR TITLE
Catch interrupts in phyperopt, return current data

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,43 +106,6 @@ end
         @test !occursin("Parameter b", text)
     end
 
-    @testset "Interrupt handling" begin
-        @info "Testing Interrupt handling"
-        # TODO this seems problematic, i will not be in sequence for the parallel ones?
-        
-        # @hyperopt
-        hop = @hyperopt for i=10, a = LinRange(1,5,10)
-            i == 1 && throw(InterruptException())
-            a
-        end
-        @test_throws Exception @hyperopt for i=10, a = LinRange(1,5,10)
-            i == 1 && throw(Exception("injected error"))
-            a
-        end
-
-        # @thyperopt
-        hop = @hyperopt for i=10, a = LinRange(1,5,10)
-            i == 1 && throw(InterruptException())
-            a
-        end
-        @test_throws Exception @hyperopt for i=10, a = LinRange(1,5,10)
-            i == 1 && throw(Exception("injected error"))
-            a
-        end
-
-        # @phyperopt
-        Distributed.nworkers() ≤ 1 && addprocs(2)
-        @everywhere using Hyperopt
-        hop = @phyperopt for i=10, a = LinRange(1,5,10)
-            i == 1 && throw(InterruptException())
-            a
-        end
-        @test_throws Exception @phyperopt for i=10, a = LinRange(1,5,10)
-            i >= 1 && throw(Exception("injected error"))
-            a
-        end
-    end
-
     #     minimum.((hor,hob,hot,hof))
     # end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,6 +106,43 @@ end
         @test !occursin("Parameter b", text)
     end
 
+    @testset "Interrupt handling" begin
+        @info "Testing Interrupt handling"
+        # TODO this seems problematic, i will not be in sequence for the parallel ones?
+        
+        # @hyperopt
+        hop = @hyperopt for i=10, a = LinRange(1,5,10)
+            i == 1 && throw(InterruptException())
+            a
+        end
+        @test_throws Exception @hyperopt for i=10, a = LinRange(1,5,10)
+            i == 1 && throw(Exception("injected error"))
+            a
+        end
+
+        # @thyperopt
+        hop = @hyperopt for i=10, a = LinRange(1,5,10)
+            i == 1 && throw(InterruptException())
+            a
+        end
+        @test_throws Exception @hyperopt for i=10, a = LinRange(1,5,10)
+            i == 1 && throw(Exception("injected error"))
+            a
+        end
+
+        # @phyperopt
+        Distributed.nworkers() ≤ 1 && addprocs(2)
+        @everywhere using Hyperopt
+        hop = @phyperopt for i=10, a = LinRange(1,5,10)
+            i == 1 && throw(InterruptException())
+            a
+        end
+        @test_throws Exception @phyperopt for i=10, a = LinRange(1,5,10)
+            i >= 1 && throw(Exception("injected error"))
+            a
+        end
+    end
+
     #     minimum.((hor,hob,hot,hof))
     # end
 


### PR DESCRIPTION
In `@hypteropt` it will catch interrupts and return the data generated so far. I wanted the same functionality for long running distributed jobs, and implemented pretty much the same thing for `@phyperopt` (and `@thyperopt` also I just realized, have not tried this though and might need to adapt to function well with that) since I didn't see any immediate reasons it would create problems. 

Was there any specific reason this didn't exist before, something problematic that I didn't see?

If you want this, should I create some tests? Not sure of a good way to generate external interrupts, but should be the same as throwing a `InterruptedException` after some time in the optimization function right?