### PR TITLE
NaN should map to -Inf for maximizer

### DIFF
--- a/src/Hyperopt.jl
+++ b/src/Hyperopt.jl
@@ -40,8 +40,8 @@ end
 function Base.getproperty(ho::Hyperoptimizer, s::Symbol)
     s === :minimum && (return isempty(ho.results) ? NaN :  minimum(replace(ho.results, NaN => Inf)))
     s === :minimizer && (return isempty(ho.results) ? [] :  ho.history[argmin(replace(ho.results, NaN => Inf))])
-    s === :maximum && (return isempty(ho.results) ? NaN :  maximum(replace(ho.results, NaN => Inf)))
-    s === :maximizer && (return isempty(ho.results) ? [] :  ho.history[argmax(replace(ho.results, NaN => Inf))])
+    s === :maximum && (return isempty(ho.results) ? NaN :  maximum(replace(ho.results, NaN => -Inf)))
+    s === :maximizer && (return isempty(ho.results) ? [] :  ho.history[argmax(replace(ho.results, NaN => -Inf))])
     return getfield(ho,s)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,6 +41,14 @@ end
         @test length(hor.history) == 102
         @test length(hor.results) == 102
 
+        # Test NaN handling
+        ho2 = @hyperopt for i=2, sampler=RandomSampler(), a = [20]
+            i == 1 ? a : NaN
+        end
+        @test minimum(ho2) == 20
+        @test maximum(ho2) == 20
+        @test minimizer(ho2) == 20
+        @test maximizer(ho2) == 20
     end
 
     @testset "Latin hypercube" begin


### PR DESCRIPTION
I feel like this makes more sense, otherwise the NaN value will always be picked for maximizers?